### PR TITLE
feat : 댓글 추가 및 삭제 기능 추가

### DIFF
--- a/src/main/java/com/nikitoe/board/controller/BoardApiController.java
+++ b/src/main/java/com/nikitoe/board/controller/BoardApiController.java
@@ -1,6 +1,7 @@
 package com.nikitoe.board.controller;
 
 import com.nikitoe.board.config.auth.PrincipalDetail;
+import com.nikitoe.board.dto.ReplySaveRequestDto;
 import com.nikitoe.board.dto.ResponseDto;
 import com.nikitoe.board.model.Board;
 import com.nikitoe.board.service.BoardService;
@@ -22,9 +23,7 @@ public class BoardApiController {
     private final BoardService boardService;
 
     @PostMapping("/api/board")
-    public ResponseDto<Integer> save(@RequestBody Board board,
-        @AuthenticationPrincipal PrincipalDetail principalDetail
-    ) {
+    public ResponseDto<Integer> save(@RequestBody Board board, @AuthenticationPrincipal PrincipalDetail principalDetail) {
         boardService.writePost(board, principalDetail.getUser());
         return new ResponseDto<>(HttpStatus.OK, 1);
     }
@@ -39,6 +38,17 @@ public class BoardApiController {
     public ResponseDto<Integer> update(@PathVariable int id, @RequestBody Board board) {
         boardService.updatePost(id, board);
         return new ResponseDto<>(HttpStatus.OK, 1);
+    }
+
+    @PostMapping("/api/board/{boardId}/reply")
+    public ResponseDto<Integer> saveReply(@RequestBody ReplySaveRequestDto reply){
+        boardService.writeReply(reply);
+        return new ResponseDto<>(HttpStatus.OK,1);
+    }
+    @DeleteMapping("/api/board/reply/{replyId}")
+    private ResponseDto<Integer> deleteReply(@PathVariable long replyId){
+        boardService.deleteReply(replyId);
+        return new ResponseDto<>(HttpStatus.OK,1);
     }
 
 }

--- a/src/main/java/com/nikitoe/board/model/Board.java
+++ b/src/main/java/com/nikitoe/board/model/Board.java
@@ -1,6 +1,8 @@
 package com.nikitoe.board.model;
 
 import java.sql.Timestamp;
+import java.util.List;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -10,6 +12,8 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,6 +45,10 @@ public class Board {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId")
     private User user;
+
+    @OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+    @OrderBy("id desc")
+    private List<Reply> replys;
 
     @CreationTimestamp
     private Timestamp createDate;

--- a/src/main/java/com/nikitoe/board/service/BoardService.java
+++ b/src/main/java/com/nikitoe/board/service/BoardService.java
@@ -1,8 +1,12 @@
 package com.nikitoe.board.service;
 
+import com.nikitoe.board.dto.ReplySaveRequestDto;
 import com.nikitoe.board.model.Board;
+import com.nikitoe.board.model.Reply;
 import com.nikitoe.board.model.User;
 import com.nikitoe.board.repository.BoardRepository;
+import com.nikitoe.board.repository.ReplyRepository;
+import com.nikitoe.board.repository.UserRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardService {
 
     private final BoardRepository boardRepository;
+    private final UserRepository userRepository;
+    private final ReplyRepository replyRepository;
 
     @Transactional
     public void writePost(Board board, User user) {
@@ -46,5 +52,25 @@ public class BoardService {
         board.setContent(requestBoard.getContent());
 
     }
+
+    @Transactional
+    public void writeReply(ReplySaveRequestDto replyDto){
+        Board board = boardRepository.findById(replyDto.getBoardId())
+            .orElseThrow(()-> new IllegalArgumentException("Failed to write reply : cannot find post id"));
+
+        User user = userRepository.findById(replyDto.getUserId())
+            .orElseThrow(()-> new IllegalArgumentException("Failed to write reply : cannot find post id"));
+
+        Reply reply = Reply.builder()
+            .user(user)
+            .board(board)
+            .content(replyDto.getContent())
+            .build();
+
+        replyRepository.save(reply);
+    }
+
+    @Transactional
+    public void deleteReply(long replyId){replyRepository.deleteById(replyId);}
 
 }

--- a/src/main/resources/static/js/board.js
+++ b/src/main/resources/static/js/board.js
@@ -7,6 +7,10 @@ let index = {
     $("#btn-update").on("click", () => {
       this.update();
     });
+
+    $("#btn-reply-save").on("click", () => {
+      this.saveReply();
+    });
   },
 
   save: function () {
@@ -35,7 +39,6 @@ let index = {
       category: $("#category").val(),
       content: $("#content").val()
     }
-
     $.ajax({
       type: "PUT",
       url: "/api/board/" + id,
@@ -48,6 +51,7 @@ let index = {
       alert("Failed Update Post");
     })
   },
+
   deleteById: function (boardId) {
     $.ajax({
       type: "DELETE",
@@ -58,6 +62,38 @@ let index = {
       location.href = "/";
     }).fail(function (error) {
       alert("Failed Delete Post");
+    })
+  },
+
+  saveReply: function () {
+    let data = {
+      userId: $("#userId").val(),
+      boardId: $("#boardId").val(),
+      content: $("#reply-content").val()
+    }
+    $.ajax({
+      type: "POST",
+      url: `/api/board/${data.boardId}/reply`,
+      data: JSON.stringify(data),
+      contentType: "application/json; charset=utf-8",
+    }).done(function (resp) {
+      alert("Success Save Reply");
+      location.href = `/board/${data.boardId}`;
+    }).fail(function (error) {
+      alert(JSON.stringify(error));
+    })
+  },
+
+  deleteReply: function (boardId, replyId) {
+    $.ajax({
+      type: "DELETE",
+      url: `/api/board/reply/${replyId}`,
+      contentType: "application/json; charset=utf-8",
+    }).done(function (resp) {
+      alert("Success Delete Reply");
+      location.href = `/board/${boardId}`;
+    }).fail(function (error) {
+      alert(JSON.stringify(error));
     })
   }
 }

--- a/src/main/webapp/WEB-INF/views/board/detail.jsp
+++ b/src/main/webapp/WEB-INF/views/board/detail.jsp
@@ -23,6 +23,35 @@
     <div class="form-group">
         <div>${boards.content}</div>
     </div>
+    <div class="card">
+        <form>
+            <input type="hidden" id="userId" value="${principal.user.id}">
+            <input type="hidden" id="boardId" value="${boards.id}">
+            <div class="card-body">
+                <textarea id="reply-content" class="form-control" rows="1"></textarea>
+            </div>
+            <div class="card-footer">
+                <button type="button" id="btn-reply-save" class="btn btn-primary">Save</button>
+            </div>
+        </form>
+    </div>
+    <br>
+    <div class="card">
+        <div class="card-header">ReplyList</div>
+        <ul id="reply-box" class="list-group">
+            <c:forEach var="reply" items="${boards.replys}">
+                <li id="reply-${reply.id}" class="list-group-item d-flex justify-content-between">
+                    <div>${reply.content}</div>
+                    <div class="d-flex">
+                        <div class="font-italic">Writer : ${reply.user.username}</div><br>
+                        <c:if test="${principal.user.username eq reply.user.username}">
+                            <button onclick="index.deleteReply(${boards.id}, ${reply.id})" class="badge">Remove</button>
+                        </c:if>
+                    </div>
+                </li>
+            </c:forEach>
+        </ul>
+    </div>
 
 </div>
 <script type="text/javascript" src="/js/board.js"></script>


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 댓글 쓰기
  - 인증된 사용자라면 게시글 디테일을 클릭
  - 하단의 댓글 입력 부분에 댓들 작성후 등록
  - 성공적으로 저장 시 alert 메시지 출력
- 댓글 삭제
  - 인증된 사용자라면 게시글 디테일 클릭
  - 하단의 댓글 리스트 부분에 댓글 목록 출력
  - 만약 댓글 중 현재 사용자라면 id의 해당하는 댓글에는 remove 버튼 활성화
  - remove 버튼 클릭 시, 정작으로 삭제가 되면 alert 메시지 출력
- 댓글 불러오기
  - 인증된 사용자라면 게시글 디테일을 클릭
  - 하단의 댓글 리스트 부분에 댓글 목록 출력
  - 만약 댓글 중 현재 사용자라면 id의 해당하는 댓글에는 remove 버튼 활성화
  - 아닌 경우에는 remove 버튼 비활성화

**TO-BE**

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [✅] API 테스트 